### PR TITLE
修复因 ctypes 库导致的兼容性问题

### DIFF
--- a/Aumiao-py/main.py
+++ b/Aumiao-py/main.py
@@ -1,7 +1,7 @@
+import platform
 import logging
 import sys
 from collections.abc import Callable
-from ctypes import windll
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -9,6 +9,10 @@ from typing import Literal, TypeVar, cast
 
 from src import client, community, user, whale
 from src.utils import tool
+
+# 基于系统，判断是否需要引入ctypes库
+if platform.system() == 'Windows':
+	from ctypes import windll
 
 # 常量定义
 MAX_MENU_KEY_LENGTH = 2

--- a/Aumiao-py/main.py
+++ b/Aumiao-py/main.py
@@ -1,5 +1,5 @@
-import platform
 import logging
+import platform
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -9,10 +9,6 @@ from typing import Literal, TypeVar, cast
 
 from src import client, community, user, whale
 from src.utils import tool
-
-# 基于系统，判断是否需要引入ctypes库
-if platform.system() == 'Windows':
-	from ctypes import windll
 
 # 常量定义
 MAX_MENU_KEY_LENGTH = 2
@@ -77,7 +73,10 @@ def print_header(text: str) -> None:
 
 def enable_vt_mode() -> None:
 	"""启用Windows虚拟终端模式"""
-	if sys.platform == "win32":
+	if platform.system() == "Windows":
+		# 基于系统, 判断是否需要引入ctypes库
+		from ctypes import windll  # noqa: PLC0415
+
 		try:
 			kernel32 = windll.kernel32
 			kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)


### PR DESCRIPTION
在macOS/Linux系统上，会因为无法从`ctypes` 模块导入 `windll`而报错。在非Windows环境下肯定没有windll这种东西。

所以写了一个判断，如果系统是Windows系统，则会导入 ctypes 模块，反之则不会导入，使用macOS/Linux终端自带的ANSI颜色。

在本地测试是能用的，不知道在Windows上用可不可以

:)